### PR TITLE
Add relative_dir method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies.figment]
-version = "^0.10"
+version = "^0.10.12"
 features = ["parse-value"]
 
 [dev_dependencies.serde]
@@ -25,5 +25,5 @@ version = "1"
 features = ["derive"]
 
 [dev_dependencies.figment]
-version = "^0.10"
+version = "^0.10.12"
 features = ["env", "test", "toml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies.figment]
-version = "^0.10.12"
+version = "^0.10, >=0.10.12"
 features = ["parse-value"]
 
 [dev_dependencies.serde]
@@ -25,5 +25,5 @@ version = "1"
 features = ["derive"]
 
 [dev_dependencies.figment]
-version = "^0.10.12"
+version = "^0.10, >=0.10.12"
 features = ["env", "test", "toml"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl FileAdapter {
     /// let file_adapter = FileAdapter::wrap(Env::prefixed("MY_APP_")).relative_to_dir("foo");
     /// ```
     pub fn relative_to_dir<P: AsRef<Path>>(self, path: P) -> Self {
-        let mut relative_dir = self.relative_dir.join(path);
+        let relative_dir = self.relative_dir.join(path);
 
         Self {
             relative_dir,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,9 +249,9 @@ impl FileAdapter {
     /// use figment::providers::Env;
     /// use figment_file_provider_adapter::FileAdapter;
     /// // This provider will only at the variables prefixed with MY_APP_ and attempt to resolve any _FILE reference relative to the "foo" directory.
-    /// let file_adapter = FileAdapter::wrap(Env::prefixed("MY_APP_")).relative_dir("foo");
+    /// let file_adapter = FileAdapter::wrap(Env::prefixed("MY_APP_")).relative_to_dir("foo");
     /// ```
-    pub fn relative_dir<P: AsRef<Path>>(self, path: P) -> Self {
+    pub fn relative_to_dir<P: AsRef<Path>>(self, path: P) -> Self {
         let mut relative_dir = self.relative_dir.clone();
         relative_dir.push(path);
         Self {
@@ -546,7 +546,7 @@ mod tests {
             assert!(!subdir.is_absolute());
 
             let config = figment::Figment::new()
-                .merge(FileAdapter::wrap(Env::prefixed("FIGMENT_TEST_")).relative_dir(subdir))
+                .merge(FileAdapter::wrap(Env::prefixed("FIGMENT_TEST_")).relative_to_dir(subdir))
                 .extract::<Config>()?;
 
             assert_eq!(config.foo, "bar");
@@ -566,7 +566,7 @@ mod tests {
             assert!(abs_dir.is_absolute());
 
             let config = figment::Figment::new()
-                .merge(FileAdapter::wrap(Env::prefixed("FIGMENT_TEST_")).relative_dir(abs_dir))
+                .merge(FileAdapter::wrap(Env::prefixed("FIGMENT_TEST_")).relative_to_dir(abs_dir))
                 .extract::<Config>()?;
 
             assert_eq!(config.foo, "bar");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
     #[test]
     fn basic_env_file_with_relative_dir() {
         figment::Jail::expect_with(|jail| {
-            jail.set_env("FIGMENT_TEST_FOO_FILE", "subdir/secret");
+            jail.set_env("FIGMENT_TEST_FOO_FILE", "secret");
             jail.create_file("subdir/secret", "bar")?;
 
             let config = figment::Figment::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,8 +252,8 @@ impl FileAdapter {
     /// let file_adapter = FileAdapter::wrap(Env::prefixed("MY_APP_")).relative_to_dir("foo");
     /// ```
     pub fn relative_to_dir<P: AsRef<Path>>(self, path: P) -> Self {
-        let mut relative_dir = self.relative_dir.clone();
-        relative_dir.push(path);
+        let mut relative_dir = self.relative_dir.join(path);
+
         Self {
             relative_dir,
             ..self


### PR DESCRIPTION
Add a relative dir method to allow setting a base directory from which to read secrets files.
